### PR TITLE
Fix comments which start with non-alphanumerics

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -602,8 +602,7 @@ static Symbolic s_symop(wchar_vec s, State *state) {
       default: return con_or_var(c);
     }
   } else {
-    bool is_comment = true;
-    for (size_t i = 0; i < s.len; i++) { is_comment &= s.data[i] == '-'; }
+    bool is_comment = (s.data[0] == '-') & (s.data[1] == '-');
     if (is_comment) return S_COMMENT;
     if (s.len == 2) {
       if (s.data[0] == '$' && s.data[1] == '$' && valid_splice(state)) return S_SPLICE;


### PR DESCRIPTION
Closes #7.

Comments get parsed incorrectly if they start with some symbols, e.g. `.` or `#` or `|`, but not `;` or `,`. This commit makes everything starting with `--` into a comment.
Just in case, it can't break any infix operator because no operator in PureScript can contain `--`.

I've never before touched C so I'd be thankful for edits suggestions.